### PR TITLE
feat: add profile for FBW A380X

### DIFF
--- a/src/aircraft/FlyByWireA380X.ts
+++ b/src/aircraft/FlyByWireA380X.ts
@@ -1,0 +1,141 @@
+import { AircraftConfigSimType, AircraftFeature, FeatureType } from '../defs'
+import {
+    AircraftConfig,
+    FeatureAddresses,
+    FeatureState,
+    FlapNames,
+    Meta,
+} from '../interface/aircraft'
+
+export default class FlyByWireA380X extends AircraftConfig {
+    meta: Meta = {
+        id: 'flybywire_a380x',
+        name: 'FlyByWire A380X',
+        sim: AircraftConfigSimType.MsFs,
+        enabled: true,
+        priority: 2,
+        author: 'Arthur Parienté <https://github.com/arthurpar06>'
+    }
+
+    features: FeatureAddresses = {
+        [AircraftFeature.BeaconLights]: {
+            LIGHTING_BEACON_0: FeatureType.Int,
+        },
+        [AircraftFeature.LandingLights]: {
+            LIGHTING_LANDING_2: FeatureType.Int,
+        },
+        [AircraftFeature.LogoLights]: {
+            // Lhe logo light isn't available in the FBW A380X at the moment; in the sim, the navigation light currently controls the logo ligh
+            LIGHTING_NAV_0: FeatureType.Int,
+        },
+        [AircraftFeature.NavigationLights]: {
+            LIGHTING_NAV_0: FeatureType.Int,
+        },
+        [AircraftFeature.StrobeLights]: {
+            LIGHTING_STROBE_0: FeatureType.Int,
+        },
+        [AircraftFeature.TaxiLights]: {
+            LIGHTING_LANDING_1: FeatureType.Int,
+        },
+        [AircraftFeature.WingLights]: {
+            LIGHTING_WING_0: FeatureType.Int,
+        },
+        [AircraftFeature.APU]: {
+            A32NX_OVHD_APU_MASTER_SW_PB_IS_ON: FeatureType.Int,
+            A32NX_OVHD_APU_START_SW_PB_IS_ON: FeatureType.Int,
+        },
+        [AircraftFeature.Battery]: {
+            A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO: FeatureType.Int,
+            A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO: FeatureType.Int,
+            A32NX_OVHD_ELEC_BAT_ESS_PB_IS_AUTO: FeatureType.Int,
+            A32NX_OVHD_ELEC_BAT_APU_PB_IS_AUTO: FeatureType.Int,
+        },
+        [AircraftFeature.Seatbelts]: {
+            XMLVAR_SWITCH_OVHD_INTLT_SEATBELT_Position: FeatureType.Int,
+            A32NX_FLAPS_HANDLE_INDEX: FeatureType.Int,
+            A32NX_GEAR_HANDLE_POSITION: FeatureType.Int,
+        },
+        [AircraftFeature.EmergencyLights]: {
+            XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_Position: FeatureType.Int,
+        },
+        [AircraftFeature.AntiIce]: {
+            XMLVAR_Momentary_PUSH_OVHD_ANTIICE_ENG1_Pressed: FeatureType.Int,
+            XMLVAR_Momentary_PUSH_OVHD_ANTIICE_ENG2_Pressed: FeatureType.Int,
+            XMLVAR_Momentary_PUSH_OVHD_ANTIICE_ENG3_Pressed: FeatureType.Int,
+            XMLVAR_Momentary_PUSH_OVHD_ANTIICE_ENG4_Pressed: FeatureType.Int,
+            XMLVAR_Momentary_PUSH_OVHD_ANTIICE_WING_Pressed: FeatureType.Int,
+        }
+    }
+
+    flapNames: FlapNames = {
+        0: 'UP',
+        1: 'CONF 1',
+        2: 'CONF 1+F',
+        3: 'CONF 2',
+        4: 'CONF 3',
+        5: 'FULL',
+    }
+
+    match(title: string, icao: string, config_path: string): boolean {
+        if (!title.includes('a380')) {
+            return false;
+        }
+
+        return ['fbw', 'flybywire'].some((w) => title.includes(w));
+    }
+
+    beaconLights(value: number): FeatureState {
+        return value === 1;
+    }
+
+    landingLights(value: number): FeatureState {
+        return value === 1;
+    }
+
+    logoLights(value: number): FeatureState {
+        return value === 1;
+    }
+
+    navigationLights(value: number): FeatureState {
+        return value === 1;
+    }
+
+    strobeLights(value: number): FeatureState {
+        if (value === 1) {
+            return null;
+        }
+        return value === 0;
+    }
+
+    wingLights(value: number): FeatureState {
+        return value === 1;
+    }
+
+    taxiLights(value: number): FeatureState {
+        return value === 0 || value === 1;
+    }
+
+    APU(mastersw: number, startsw: number): FeatureState {
+        return mastersw === 1 && startsw === 1;
+    }
+
+    battery(bat1: number, bat2: number, ess: number, apu: number): FeatureState {
+        return bat1 === 1 || bat2 === 1 || ess === 1 || apu === 1
+    }
+
+    emergencyLights(value: number): FeatureState {
+        return value !== 2;
+    }
+
+    seatbelts(value: number, flapsPosition: number, gearPosition: number): FeatureState {
+        if (value === 1) {
+            return flapsPosition !== 0 || gearPosition === 1;
+        }
+        
+        return value === 0;
+    }
+
+    antiIce(eng1: number, eng2: number, eng3: number, eng4: number, wing: number): FeatureState {
+        return eng1 === 1 || eng2 === 1 || eng3 === 1 || eng4 === 1 || wing === 1;
+    }
+}

--- a/src/aircraft/FlyByWireA380X.ts
+++ b/src/aircraft/FlyByWireA380X.ts
@@ -48,7 +48,6 @@ export default class FlyByWireA380X extends AircraftConfig {
             A32NX_OVHD_ELEC_BAT_1_PB_IS_AUTO: FeatureType.Int,
             A32NX_OVHD_ELEC_BAT_2_PB_IS_AUTO: FeatureType.Int,
             A32NX_OVHD_ELEC_BAT_ESS_PB_IS_AUTO: FeatureType.Int,
-            A32NX_OVHD_ELEC_BAT_APU_PB_IS_AUTO: FeatureType.Int,
         },
         [AircraftFeature.Seatbelts]: {
             XMLVAR_SWITCH_OVHD_INTLT_SEATBELT_Position: FeatureType.Int,
@@ -117,8 +116,9 @@ export default class FlyByWireA380X extends AircraftConfig {
         return mastersw === 1 && startsw === 1;
     }
 
-    battery(bat1: number, bat2: number, ess: number, apu: number): FeatureState {
-        return bat1 === 1 || bat2 === 1 || ess === 1 || apu === 1
+    battery(bat1: number, bat2: number, ess: number): FeatureState {
+        // Since each battery is worth one when on, we can simply add them and check the sum. We need at least two batteries to be on.
+        return bat1 + bat2 + ess >= 2;
     }
 
     emergencyLights(value: number): FeatureState {

--- a/src/aircraft/FlyByWireA380X.ts
+++ b/src/aircraft/FlyByWireA380X.ts
@@ -52,8 +52,6 @@ export default class FlyByWireA380X extends AircraftConfig {
         },
         [AircraftFeature.Seatbelts]: {
             XMLVAR_SWITCH_OVHD_INTLT_SEATBELT_Position: FeatureType.Int,
-            A32NX_FLAPS_HANDLE_INDEX: FeatureType.Int,
-            A32NX_GEAR_HANDLE_POSITION: FeatureType.Int,
         },
         [AircraftFeature.EmergencyLights]: {
             XMLVAR_SWITCH_OVHD_INTLT_EMEREXIT_Position: FeatureType.Int,
@@ -115,7 +113,7 @@ export default class FlyByWireA380X extends AircraftConfig {
         return value === 0 || value === 1;
     }
 
-    APU(mastersw: number, startsw: number): FeatureState {
+    apu(mastersw: number, startsw: number): FeatureState {
         return mastersw === 1 && startsw === 1;
     }
 
@@ -127,12 +125,8 @@ export default class FlyByWireA380X extends AircraftConfig {
         return value !== 2;
     }
 
-    seatbelts(value: number, flapsPosition: number, gearPosition: number): FeatureState {
-        if (value === 1) {
-            return flapsPosition !== 0 || gearPosition === 1;
-        }
-        
-        return value === 0;
+    seatbelts(value: number): FeatureState {
+        return value !== 2;
     }
 
     antiIce(eng1: number, eng2: number, eng3: number, eng4: number, wing: number): FeatureState {


### PR DESCRIPTION
This PR adds a profile for the FlyByWire A380X.
Since this is my first time creating an aircraft profile, I’d appreciate any feedback you have, as I may not have done everything the right way.