### PR TITLE
Update _default_xplane.ts

### DIFF
--- a/src/aircraft/_default_xplane.ts
+++ b/src/aircraft/_default_xplane.ts
@@ -21,25 +21,19 @@ export default class DefaultXPlane extends AircraftConfig {
 
   features: FeatureAddresses = {
     [AircraftFeature.BeaconLights]: {
-      'sim/cockpit2/switches/beacon_on': FeatureType.Bool,
+      'sim/cockpit2/switches/beacon_on': FeatureType.Int,
     },
     [AircraftFeature.LandingLights]: {
-      'sim/cockpit2/switches/landing_lights_on': FeatureType.Bool,
-    },
-    [AircraftFeature.LogoLights]: {
-      'sim/cockpit2/switches/logo_lights_on': FeatureType.Bool,
+      'sim/cockpit2/switches/landing_lights_on': FeatureType.Int,
     },
     [AircraftFeature.NavigationLights]: {
-      'sim/cockpit2/switches/navigation_lights_on': FeatureType.Bool,
+      'sim/cockpit2/switches/navigation_lights_on': FeatureType.Int,
     },
     [AircraftFeature.StrobeLights]: {
-      'sim/cockpit2/switches/strobe_lights_on': FeatureType.Bool,
+      'sim/cockpit2/switches/strobe_lights_on': FeatureType.Int,
     },
     [AircraftFeature.TaxiLights]: {
-      'sim/cockpit2/switches/taxi_light_on': FeatureType.Bool,
-    },
-    [AircraftFeature.WingLights]: {
-      'sim/cockpit2/switches/wing_lights_on': FeatureType.Bool,
+      'sim/cockpit2/switches/taxi_light_on': FeatureType.Int,
     },
   }
 
@@ -102,24 +96,6 @@ export default class DefaultXPlane extends AircraftConfig {
    * @return {boolean|null}
    */
   taxiLights(value: number): FeatureState {
-    return value === 1
-  }
-
-  /**
-   * Parse the value that's returned by the sim
-   * @param value
-   * @return {boolean|null}
-   */
-  wingLights(value: number): FeatureState {
-    return value === 1
-  }
-
-  /*s*
-   * Parse the value that's returned by the sim
-   * @param value
-   * @return {boolean|null}
-   */
-  logoLights(value: number): FeatureState {
     return value === 1
   }
 }


### PR DESCRIPTION
Removed this two as they do not exist as default dataref on X-Plane:
sim/cockpit2/switches/logo_lights_on
sim/cockpit2/switches/wing_lights_on

Changing FeatureType from Bool to Int on the remaining one, aligning with datatype on X-plane
